### PR TITLE
Prototype zero-ish downtime deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 ### Required Setup
 
 This project uses Terraform to provision infrastructure. It uses AWS S3 (with Dynamo DB locking) as the state store backend. These are described in `provider.tf`. Pull requests run Terraform format check and Terraform plan. Merges to main run Terraform Apply as well.
+
+### Modules
+
+#### Prototyping Kit
+
+The prototyping kit can be found under [modules/prototype-kit/codebase](./modules/prototype-kit/codebase).
+
+To deploy a change to the kit, make any required edits, commit them and push them to the `main` branch, these changes
+are deployed via GitHub actions and generally take a minute or two to reflect. 
+
+Please bear in mind that pushing a change will **bring down the prototype for a few seconds and could reset session 
+data** so check that no one is currently using it.

--- a/modules/prototype-kit/codebase/app/config.js
+++ b/modules/prototype-kit/codebase/app/config.js
@@ -17,7 +17,7 @@ module.exports = {
 
   // Enable cookie-based session store (persists on restart)
   // Please note 4KB cookie limit per domain, cookies too large will silently be ignored
-  useCookieSessionStore: 'false',
+  useCookieSessionStore: 'true',
 
   // Enable or disable built-in docs and examples.
   useDocumentation: 'true',

--- a/modules/prototype-kit/deployment.tf
+++ b/modules/prototype-kit/deployment.tf
@@ -27,8 +27,17 @@ resource "aws_key_pair" "prototype_deployment" {
   tags       = var.tags
 }
 
+data "aws_ami" "amazon-linux-2" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm*"]
+  }
+}
+
 resource "aws_instance" "prototype_server" {
-  ami                         = "ami-01c835443b86fe988"
+  ami                         = data.aws_ami.amazon-linux-2.id
   instance_type               = "t2.micro"
   key_name                    = aws_key_pair.prototype_deployment.key_name
   associate_public_ip_address = true


### PR DESCRIPTION
Made this change so that the prototype kit can be deployed while being used for UR.

* turned on cookie based session storage
* use symbolic links to only replace running app once new one has been set up
* add a little guidance to the main readme
* get an ami id for the instance by searching (non region specific)