### PR TITLE
Fix json output for tabular parsing

### DIFF
--- a/modules/lambda-tabular-parser/Makefile
+++ b/modules/lambda-tabular-parser/Makefile
@@ -14,7 +14,7 @@ test:
 		--env S3_PREFIX="tabular-parser/" \
 		--name $(DOCKER_TEST_IMAGE_NAME) \
 		$(DOCKER_TEST_IMAGE_NAME) &
-	@sleep 2
+	@sleep 4
 	@curl -i -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -w "\n" -d @test-input.json
 	@docker kill $(DOCKER_TEST_IMAGE_NAME)
 	@docker rm $(DOCKER_TEST_IMAGE_NAME)

--- a/modules/lambda-tabular-parser/Makefile
+++ b/modules/lambda-tabular-parser/Makefile
@@ -10,8 +10,8 @@ test:
 		--env AWS_DEFAULT_REGION=$$AWS_DEFAULT_REGION \
 		--env AWS_ACCESS_KEY_ID=$$AWS_ACCESS_KEY_ID \
 		--env AWS_SECRET_ACCESS_KEY=$$AWS_SECRET_ACCESS_KEY \
-		--env S3_BUCKET="test-things-45134-data-upload" \
-		--env S3_PREFIX="excel-parser/" \
+		--env S3_BUCKET="mhclg-core-data-upload" \
+		--env S3_PREFIX="tabular-parser/" \
 		--name $(DOCKER_TEST_IMAGE_NAME) \
 		$(DOCKER_TEST_IMAGE_NAME) &
 	@sleep 2

--- a/modules/lambda-tabular-parser/main.py
+++ b/modules/lambda-tabular-parser/main.py
@@ -27,7 +27,7 @@ def handler(event, context):
                 'stored': f"s3://{environ.get('S3_BUCKET')}::{upload_key}"
             },
             'data': parse_tabular(uploaded_file),
-        }),
+        }, cls=NumpyEncoder),
         'isBase64Encoded': False,
     }
 
@@ -49,7 +49,7 @@ def parse_tabular(file):
         "columns": headers,
         "data": unique_data_values
     }
-    return json.dumps(file_structure, cls=NumpyEncoder)
+    return file_structure
 
 
 class NumpyEncoder(json.JSONEncoder):


### PR DESCRIPTION
Moved `json.dumps` to the body rather than as an output of the `parse_tabular` function.